### PR TITLE
Add GA DNS support and backup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Cloud VPN with AWS Global Accelerator
+
+This repository contains Terraform configurations and helper scripts to deploy a WireGuard VPN on AWS. The setup uses **AWS Global Accelerator** to expose a stable DNS name that clients can use instead of the instance's public IP.
+
+## Usage
+
+1. Deploy the infrastructure from the `iac/` folder using Terraform.
+2. Use `clients/add_client.sh <name>` to create a new WireGuard client configuration.
+   The script fetches the Global Accelerator DNS so the generated config will keep
+   working even if the instance IP changes.
+3. Optionally run `clients/backup_keys.sh <s3-bucket>` to archive server keys and
+   client configurations to an S3 bucket. Use `clients/restore_keys.sh <s3-bucket>`
+   on a fresh instance to restore the configuration and keep existing clients.
+
+## Restoring Configuration
+
+To spin up a new instance in another region:
+
+1. Deploy the Terraform configuration again (potentially with a different region).
+2. Run `clients/restore_keys.sh <s3-bucket>` to download the archived
+   configuration from S3 and apply it to the new instance.
+
+Because the clients use the Global Accelerator DNS, no changes are required on
+client devices.

--- a/clients/add_client.sh
+++ b/clients/add_client.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 SERVER_IP=$(terraform -chdir=../iac output -raw instance_public_ip)
+# DNS name of the Global Accelerator for client configurations
+GA_DNS=$(terraform -chdir=../iac output -raw global_accelerator_dns)
 SERVER="ubuntu@$SERVER_IP"
 SSH_KEY="../iac/ssh_keys/aws-instance-ssh-key"
 
@@ -16,6 +18,7 @@ ssh -i "$SSH_KEY" $SERVER "sudo bash -s" <<EOF
 set -e
 CLIENT_NAME="$CLIENT_NAME"
 SERVER_PUBLIC_IP="$SERVER_IP"
+SERVER_ENDPOINT="$GA_DNS"
 
 cd /etc/wireguard
 mkdir -p clients/\$CLIENT_NAME
@@ -51,7 +54,7 @@ DNS = 192.168.2.1
 
 [Peer]
 PublicKey = \$SERVER_PUB
-Endpoint = \$SERVER_PUBLIC_IP:51820
+Endpoint = \$SERVER_ENDPOINT:51820
 AllowedIPs = 0.0.0.0/0
 PersistentKeepalive = 25
 EOC
@@ -82,4 +85,3 @@ scp -i "$SSH_KEY" $SERVER:/home/ubuntu/${CLIENT_NAME}.conf .
 
 # Clean up temporary file on server
 ssh -i "$SSH_KEY" $SERVER "rm -f /home/ubuntu/${CLIENT_NAME}.conf"
-cd

--- a/clients/backup_keys.sh
+++ b/clients/backup_keys.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Backup /etc/wireguard from the server to an S3 bucket
+
+SERVER_IP=$(terraform -chdir=../iac output -raw instance_public_ip)
+SERVER="ubuntu@$SERVER_IP"
+SSH_KEY="../iac/ssh_keys/aws-instance-ssh-key"
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <s3-bucket-name>"
+  exit 1
+fi
+
+BUCKET="$1"
+TMP_DIR=$(mktemp -d)
+
+# Copy configuration from server
+scp -i "$SSH_KEY" -r $SERVER:/etc/wireguard "$TMP_DIR" || exit 1
+
+tar -czf wireguard-config.tar.gz -C "$TMP_DIR" wireguard
+aws s3 cp wireguard-config.tar.gz "s3://$BUCKET/" --sse AES256
+
+rm -rf "$TMP_DIR" wireguard-config.tar.gz
+
+echo "Backup uploaded to s3://$BUCKET/"
+

--- a/clients/restore_keys.sh
+++ b/clients/restore_keys.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Restore /etc/wireguard from an S3 bucket onto the new server
+
+SERVER_IP=$(terraform -chdir=../iac output -raw instance_public_ip)
+SERVER="ubuntu@$SERVER_IP"
+SSH_KEY="../iac/ssh_keys/aws-instance-ssh-key"
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <s3-bucket-name>"
+  exit 1
+fi
+
+BUCKET="$1"
+
+aws s3 cp "s3://$BUCKET/wireguard-config.tar.gz" wireguard-config.tar.gz || exit 1
+
+scp -i "$SSH_KEY" wireguard-config.tar.gz $SERVER:/tmp/
+ssh -i "$SSH_KEY" $SERVER "sudo tar -xzf /tmp/wireguard-config.tar.gz -C / && rm /tmp/wireguard-config.tar.gz && systemctl restart wg-quick@wg0"
+
+rm wireguard-config.tar.gz
+
+echo "Configuration restored and WireGuard restarted"
+


### PR DESCRIPTION
## Summary
- use the Global Accelerator DNS when creating client configs
- provide helper scripts to back up and restore WireGuard keys via S3
- add README with instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68723dbbb9ec832aa1d3bf3aebd38973