### PR TITLE
Add static IP option and adjust GA defaults

### DIFF
--- a/clients/add_client.sh
+++ b/clients/add_client.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 SERVER_IP=$(terraform -chdir=../iac output -raw instance_public_ip)
-# DNS name of the Global Accelerator for client configurations
-GA_DNS=$(terraform -chdir=../iac output -raw global_accelerator_dns)
+# Endpoint can be the Global Accelerator DNS, a static IP, or the instance's public IP
+VPN_ENDPOINT=$(terraform -chdir=../iac output -raw vpn_endpoint)
 SERVER="ubuntu@$SERVER_IP"
 SSH_KEY="../iac/ssh_keys/aws-instance-ssh-key"
 
@@ -18,7 +18,7 @@ ssh -i "$SSH_KEY" $SERVER "sudo bash -s" <<EOF
 set -e
 CLIENT_NAME="$CLIENT_NAME"
 SERVER_PUBLIC_IP="$SERVER_IP"
-SERVER_ENDPOINT="$GA_DNS"
+SERVER_ENDPOINT="$VPN_ENDPOINT"
 
 cd /etc/wireguard
 mkdir -p clients/\$CLIENT_NAME

--- a/iac/compute.tf
+++ b/iac/compute.tf
@@ -48,3 +48,9 @@ resource "aws_instance" "cloud_vpn_instance" {
   user_data                   = file("${path.module}/user-data.yaml")
 }
 
+resource "aws_eip" "static_ip" {
+  count    = var.assign_elastic_ip ? 1 : 0
+  instance = aws_instance.cloud_vpn_instance.id
+  vpc      = true
+}
+

--- a/iac/destroy_regional.sh
+++ b/iac/destroy_regional.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 
-# Destroy all regional resources while preserving Global Accelerator
+# Destroy all regional resources while preserving the Global Accelerator
 # This allows for seamless region migration
 
-echo "Destroying regional resources (keeping Global Accelerator)..."
+echo "Destroying regional resources (keeping Global Accelerator if deployed)..."
+
+
+GA_TARGET=""
+if terraform state list aws_globalaccelerator_endpoint_group.cloud_vpn >/dev/null 2>&1; then
+  GA_TARGET="-target=aws_globalaccelerator_endpoint_group.cloud_vpn"
+fi
 
 terraform destroy \
   -target=aws_instance.cloud_vpn_instance \
@@ -14,7 +20,7 @@ terraform destroy \
   -target=aws_route_table_association.cloud_vpn_pub_rt_assoc \
   -target=aws_security_group.cloud_vpn_sg \
   -target=aws_key_pair.cloud_vpn_ssh_key \
-  -target=aws_globalaccelerator_endpoint_group.cloud_vpn \
+  $GA_TARGET \
   -target=local_file.ssh_private_key \
   -target=local_file.ssh_public_key \
   -target=tls_private_key.ssh_key

--- a/iac/outputs.tf
+++ b/iac/outputs.tf
@@ -9,8 +9,9 @@ output "ssh_connection_command" {
   value       = "ssh -i ${local_file.ssh_private_key.filename} ubuntu@${aws_instance.cloud_vpn_instance.public_ip}"
 }
 
-# Expose the Global Accelerator DNS name
-output "global_accelerator_dns" {
-  description = "DNS name for the Global Accelerator"
-  value       = aws_globalaccelerator_accelerator.cloud_vpn.dns_name
+output "vpn_endpoint" {
+  description = "DNS name or IP clients should connect to"
+  value = var.deploy_global_accelerator ? aws_globalaccelerator_accelerator.cloud_vpn[0].dns_name : (
+    var.assign_elastic_ip ? aws_eip.static_ip[0].public_ip : aws_instance.cloud_vpn_instance.public_ip
+  )
 }

--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -4,6 +4,18 @@ variable "region" {
   default     = "us-east-1"
 }
 
+variable "deploy_global_accelerator" {
+  description = "Deploy AWS Global Accelerator to expose a stable DNS"
+  type        = bool
+  default     = false
+}
+
+variable "assign_elastic_ip" {
+  description = "Attach an Elastic IP to the instance for a persistent public IP"
+  type        = bool
+  default     = false
+}
+
 locals {
   availability_zone = "${var.region}a"
 }


### PR DESCRIPTION
## Summary
- make Global Accelerator optional by default
- allow assigning a persistent Elastic IP when GA is disabled
- remove GA specific outputs and update client script
- adjust destroy script to detect GA via state
- document new behavior and options
- cleanup README: remove S3 references and clarify global vs regional persistence

## Testing
- `terraform version` *(fails: command not found)*
- `shellcheck --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68727f3ee970832a8dc3b69adc5608cb